### PR TITLE
Swift 5.3.2 support

### DIFF
--- a/Sources/MenuBuilder Demo/MenuBuilder Demo/ViewController.swift
+++ b/Sources/MenuBuilder Demo/MenuBuilder Demo/ViewController.swift
@@ -31,11 +31,11 @@ class ViewController: NSViewController {
             MenuItem("Quit")
                 .shortcut("q")
                 .onSelect { NSApp.terminate(nil) }
+            // Uncomment once Xcode 12.5 becomes available
+            // for word in ["Hello", "World"] {
+            //     MenuItem(word)
+            // }
         }
-        // Uncomment once Xcode 12.5 becomes available
-        // for word in ["Hello", "World"] {
-        //     MenuItem(word)
-        // }
     }
 
     @IBAction func onClick(_ sender: NSButton) {

--- a/Sources/MenuBuilder Demo/MenuBuilder Demo/ViewController.swift
+++ b/Sources/MenuBuilder Demo/MenuBuilder Demo/ViewController.swift
@@ -31,10 +31,6 @@ class ViewController: NSViewController {
             MenuItem("Quit")
                 .shortcut("q")
                 .onSelect { NSApp.terminate(nil) }
-
-            for word in ["Hello", "World"] {
-                MenuItem(word)
-            }
         }
     }
 
@@ -51,7 +47,7 @@ struct MyMenuItemView: View {
     var body: some View {
         HStack {
             Slider(value: $value, in: 0...9, step: 1)
-            Text("Value: \(Int(value))").font(Font.body.monospacedDigit())
+            Text("Value: \(value)").font(Font.body.monospacedDigit())
         }
         .padding(.horizontal)
         .frame(minWidth: 250)

--- a/Sources/MenuBuilder Demo/MenuBuilder Demo/ViewController.swift
+++ b/Sources/MenuBuilder Demo/MenuBuilder Demo/ViewController.swift
@@ -32,6 +32,10 @@ class ViewController: NSViewController {
                 .shortcut("q")
                 .onSelect { NSApp.terminate(nil) }
         }
+        // Uncomment once Xcode 12.5 becomes available
+        // for word in ["Hello", "World"] {
+        //     MenuItem(word)
+        // }
     }
 
     @IBAction func onClick(_ sender: NSButton) {


### PR DESCRIPTION
This change makes the code built with Xcode 12.4 and Swift 5.3.2
Doesn't accept for loops inside function builder DSL

Additionally removal of redundant `Int` conversion