### PR TITLE
Add localized menu title support

### DIFF
--- a/Sources/MenuBuilder/MenuItem.swift
+++ b/Sources/MenuBuilder/MenuItem.swift
@@ -16,9 +16,14 @@ public struct MenuItem: AnyMenuItem {
         self.modifiers = modifiers
     }
 
-    /// Creates a menu item with the given title.
+    /// Creates a menu item with the given title (localized key).
     public init(_ title: String) {
-        modifiers = [{ item in item.title = title }]
+        modifiers = [ { item in item.title = NSLocalizedString(title, comment: "") }]
+    }
+
+    /// Creates a menu item with the given verbatim title.
+    public init(verbatim title: String) {
+        modifiers = [ { item in item.title = title }]
     }
 
     /// Creates a menu item with the given attributed title.


### PR DESCRIPTION
I didn't implement this changes to those constructors which are receiving (NS)AttributedString objects, considering that Attributed Strings are not directly localizable like plain strings.

Note: The previous constructor has been changed from `.init(_ title: String)` to `.init(verbatim title: String)`.
This might be a ground-breaking change to those projects who are already using this package.